### PR TITLE
Add automatic conversion from cite journal to cite bioRxiv

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4240,7 +4240,7 @@ final class Template
                     if (mb_stripos($periodical, 'arxiv') !== false) {
                         return;
                     }
-					 // Check for bioRxiv journal conversion - only for cite journal
+                    // Check for bioRxiv journal conversion - only for cite journal
                     if (
                         (mb_stripos($periodical, 'biorxiv') !== false || mb_strtolower($periodical) === 'biorxiv: the preprint server for biology') &&
                         $this->wikiname() === 'cite journal' &&

--- a/src/includes/constants/parameters.php
+++ b/src/includes/constants/parameters.php
@@ -435,7 +435,9 @@ const CITE_BOOK_UNSUPPORTED_PARAMS = [
     'magazine',
 ];
 
-/** Parameters allowed by cite bioRxiv template 
+/**
+ * Parameters allowed by cite bioRxiv template
+ */
 const CITE_BIORXIV_ALLOWED_PARAMS = [
     'biorxiv',
     'title',

--- a/src/includes/constants/parameters.php
+++ b/src/includes/constants/parameters.php
@@ -435,7 +435,7 @@ const CITE_BOOK_UNSUPPORTED_PARAMS = [
     'magazine',
 ];
 
-/** Parameters allowed by cite bioRxiv template
+/** Parameters allowed by cite bioRxiv template per Wikipedia documentation at https://en.wikipedia.org/wiki/Template:Cite_bioRxiv */
 const CITE_BIORXIV_ALLOWED_PARAMS = [
     'biorxiv',
     'title',

--- a/src/includes/constants/parameters.php
+++ b/src/includes/constants/parameters.php
@@ -435,6 +435,38 @@ const CITE_BOOK_UNSUPPORTED_PARAMS = [
     'magazine',
 ];
 
+/** Parameters allowed by cite bioRxiv template 
+const CITE_BIORXIV_ALLOWED_PARAMS = [
+    'biorxiv',
+    'title',
+    'trans-title',
+    'script-title',
+    'language',
+    'lang',
+    'date',
+    'year',
+    'publication-date',
+    'quote',
+    'quotation',
+    'postscript',
+    'ref',
+    'mode',
+    'class',
+    'page',
+    'pages',
+    'pp',
+    'p',
+    'at',
+    'no-pp',
+    'df',
+    'name-list-style',
+    'name-list-format',
+    'collaboration',
+    'access-date',
+    'archive-date',
+    'orig-date',
+];
+
 const ALL_ALIASES = [
     TITLE_LINK_ALIASES, ARXIV_ALIASES, COAUTHOR_ALIASES, CHAPTER_ALIASES,
     DISPLAY_AUTHORS, DISPLAY_EDITORS, DOI_BROKEN_ALIASES, FIRST_AUTHOR_ALIASES,

--- a/src/includes/constants/parameters.php
+++ b/src/includes/constants/parameters.php
@@ -435,9 +435,7 @@ const CITE_BOOK_UNSUPPORTED_PARAMS = [
     'magazine',
 ];
 
-/**
- * Parameters allowed by cite bioRxiv template
- */
+/** Parameters allowed by cite bioRxiv template
 const CITE_BIORXIV_ALLOWED_PARAMS = [
     'biorxiv',
     'title',

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1649,4 +1649,39 @@ EP - 999 }}';
         $page = $this->process_page($text);
         $this->assertSame("{{cs1 config|name-list-style=vanc}}<ref>{{cite journal | title=From fibrositis to fibromyalgia to nociplastic pain: How rheumatology helped get us here and where do we go from here? | journal=Annals of the Rheumatic Diseases | date=2024 | volume=83 | issue=11 | pages=1421–1427 | doi=10.1136/ard-2023-225327 | pmid=39107083 | pmc=11503076 | vauthors = Clauw DJ }}</ref>{{cs1 config|name-list-style=vanc}}", $page->parsed_text());
     }
+	
+    public function testBioRxivConversion(): void {
+        $text = '{{cite journal |last=Smith |first=John |title=Test Paper |journal=bioRxiv |doi=10.1101/123456 |year=2023}}';
+        $prepared = $this->prepare_citation($text);
+        $this->assertSame('cite biorxiv', $prepared->wikiname());
+        $this->assertSame('10.1101/123456', $prepared->get2('biorxiv'));
+        $this->assertNull($prepared->get2('doi'));
+        $this->assertNull($prepared->get2('journal'));
+    }
+
+    public function testBioRxivParameterFiltering(): void {
+        $text = '{{cite journal |title=Test |journal=bioRxiv |doi=10.1101/062109 |volume=10 |pmid=123 |pmc=456}}';
+        $prepared = $this->prepare_citation($text);
+        $this->assertSame('cite biorxiv', $prepared->wikiname());
+        $this->assertNull($prepared->get2('volume'));
+        $this->assertNull($prepared->get2('pmid'));
+        $this->assertNull($prepared->get2('pmc'));
+    }
+
+    public function testBioRxivNoConversion(): void {
+        $text = '{{cite journal |title=Test |journal=bioRxiv |doi=10.1234/wrong}}';
+        $prepared = $this->prepare_citation($text);
+        $this->assertSame('cite journal', $prepared->wikiname());
+    }
+
+    public function testBioRxivNoConversionDifferentJournal(): void {
+        $text = '{{cite journal |title=Test Paper |journal=Nature |doi=10.1101/123456 |volume=500 |pages=123-456}}';
+        $prepared = $this->prepare_citation($text);
+        $this->assertSame('cite journal', $prepared->wikiname());
+        $this->assertSame('Nature', $prepared->get2('journal'));
+        $this->assertSame('10.1101/123456', $prepared->get2('doi'));
+        $this->assertSame('500', $prepared->get2('volume'));
+        $this->assertSame('123–456', $prepared->get2('pages'));
+        $this->assertNull($prepared->get2('biorxiv'));
+    }
 }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1649,7 +1649,7 @@ EP - 999 }}';
         $page = $this->process_page($text);
         $this->assertSame("{{cs1 config|name-list-style=vanc}}<ref>{{cite journal | title=From fibrositis to fibromyalgia to nociplastic pain: How rheumatology helped get us here and where do we go from here? | journal=Annals of the Rheumatic Diseases | date=2024 | volume=83 | issue=11 | pages=1421–1427 | doi=10.1136/ard-2023-225327 | pmid=39107083 | pmc=11503076 | vauthors = Clauw DJ }}</ref>{{cs1 config|name-list-style=vanc}}", $page->parsed_text());
     }
-	
+
     public function testBioRxivConversion(): void {
         $text = '{{cite journal |last=Smith |first=John |title=Test Paper |journal=bioRxiv |doi=10.1101/123456 |year=2023}}';
         $prepared = $this->prepare_citation($text);


### PR DESCRIPTION
Implements logic to convert cite journal templates referencing bioRxiv (with appropriate DOIs) to cite biorxiv, renaming and filtering parameters to match allowed fields. Adds CITE_BIORXIV_ALLOWED_PARAMS constant and corresponding PHPUnit tests to verify conversion and parameter filtering behavior.