### PR TITLE
Fix testS2CIDlicenseTrue2

### DIFF
--- a/tests/phpunit/includes/api/S2apiTest.php
+++ b/tests/phpunit/includes/api/S2apiTest.php
@@ -25,7 +25,7 @@ final class S2apiTest extends testBaseClass {
 
     public function testS2CIDlicenseTrue2(): void {
         $this->sleep_S2();
-        $this->assertTrue(get_semanticscholar_license('73436496'));
+        $this->assertTrue(get_semanticscholar_license('256282907'));
     }
 
     public function testSemanticscholar2(): void {


### PR DESCRIPTION
S2CID 73436496 flipped from open→closed. Replaced with S2CID 256282907 — arXiv:2301.10140 "The Semantic Scholar Open Data Platform", a paper authored by Semantic Scholar themselves which should stay open.