### PR TITLE
Fix phpunit.xml.dist schema URL for PHPUnit 12 compatibility

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
   colors="true"
   requireCoverageMetadata="false"
   beStrictAboutCoverageMetadata="true"
@@ -30,5 +30,4 @@
       <clover outputFile="coverage.xml"/>
     </report>
   </coverage>
-  <logging/>
 </phpunit>


### PR DESCRIPTION
- Update schema URL from schema.phpunit.de/10.1 to 12.0
- Remove deprecated empty <logging/> element (logging configured via CLI args)