### PR TITLE
Replace deprecated mb_ereg functions with PCRE equivalents

### DIFF
--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -96,7 +96,7 @@ function format_surname(string $surname): string {
     if (preg_match('~^\S\.?$~u', $surname)) {
         return mb_strtoupper($surname); // Just a single initial, with or without period
     }
-    $surname = mb_convert_case(mb_trim(mb_ereg_replace("-", " - ", $surname)), MB_CASE_LOWER);
+    $surname = mb_convert_case(mb_trim(preg_replace("/-/u", " - ", $surname)), MB_CASE_LOWER);
     if (mb_substr($surname, 0, 2) === "o'") {
         return "O'" . format_surname_2(mb_substr($surname, 2));
     }
@@ -113,7 +113,7 @@ function format_surname(string $surname): string {
 }
 
 function format_surname_2(string $surname): string {
-    $ret = mb_ereg_replace(" - ", "-", $surname);
+    $ret = str_replace(" - ", "-", $surname);
     $ret = preg_replace_callback("~(\p{L})(\p{L}+)~u",
         static function (array $matches): string {
                 return mb_strtoupper($matches[1]) . mb_strtolower($matches[2]);

--- a/src/includes/NameTools.php
+++ b/src/includes/NameTools.php
@@ -96,7 +96,7 @@ function format_surname(string $surname): string {
     if (preg_match('~^\S\.?$~u', $surname)) {
         return mb_strtoupper($surname); // Just a single initial, with or without period
     }
-    $surname = mb_convert_case(mb_trim(preg_replace("/-/u", " - ", $surname)), MB_CASE_LOWER);
+    $surname = mb_convert_case(mb_trim(preg_replace("~-~u", " - ", $surname)), MB_CASE_LOWER);
     if (mb_substr($surname, 0, 2) === "o'") {
         return "O'" . format_surname_2(mb_substr($surname, 2));
     }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -5814,10 +5814,10 @@ final class Template
                         $value = $matches[1];
                         $this->set($param, $value);
                     }
-                    if (!preg_match("~^[A-Za-z ]+\-~", $value) && mb_ereg(REGEXP_TO_EN_DASH, $value) && can_safely_modify_dashes($value) && $pmatch[1] !== 'page') {
+                    if (!preg_match("~^[A-Za-z ]+\-~", $value) && preg_match(REGEXP_TO_EN_DASH, $value) && can_safely_modify_dashes($value) && $pmatch[1] !== 'page') {
                         $this->mod_dashes = true;
                         report_modification("Upgrading to en-dash in " . echoable($param) . " parameter");
-                        $value = mb_ereg_replace(REGEXP_TO_EN_DASH, REGEXP_EN_DASH, $value);
+                        $value = preg_replace(REGEXP_TO_EN_DASH, REGEXP_EN_DASH, $value);
                         $this->set($param, $value);
                     }
                     if (

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -726,7 +726,7 @@ function mb_ucwords(string $string): string {
         static function (array $match): string {
             return $match[3] ?? mb_strtoupper($match[1]) . $match[2];
         },
-        $string);
+        $string) ?? $string;
 }
 
 function mb_substr_replace(string $string, string $replacement, int $start, int $length): string {

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -722,15 +722,11 @@ function mb_strrev(string $string, string $encode = ''): string {
 }
 
 function mb_ucwords(string $string): string {
-    if (mb_ereg_search_init($string, '(\S)(\S*\s*)|(\s+)')) {
-        $output = '';
-        while ($match = mb_ereg_search_regs()) {
-            $output .= $match[3] ? $match[3] : mb_strtoupper($match[1]) . $match[2];
-        }
-        return $output;
-    } else {
-        return $string;  // @codeCoverageIgnore
-    }
+    return preg_replace_callback('~(\S)(\S*\s*)|(\s+)~u',
+        static function (array $match): string {
+            return $match[3] ?? mb_strtoupper($match[1]) . $match[2];
+        },
+        $string);
 }
 
 function mb_substr_replace(string $string, string $replacement, int $start, int $length): string {

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -1333,7 +1333,7 @@ function find_indentifiers_in_urls_INSIDE(Template $template, string $url, strin
         $ch_pmc = bot_curl_init($time, []);
     }
 
-    $update_url = function (string $url_type, string $url) use ($url_sent, $template) {
+    $update_url = function (string $url_type, string $url) use ($url_sent, $template): void {
         if (!$url_sent) {
             $template->set($url_type, $url);
         }

--- a/src/includes/constants/regular_expressions.php
+++ b/src/includes/constants/regular_expressions.php
@@ -7,9 +7,9 @@ const REGEXP_PLAIN_WIKILINK_ONLY = '~^\[\[([^|\[\]]+?)\]\]$~';
 /** Matches: [1], target; [2], display text */
 const REGEXP_PIPED_WIKILINK = '~\[\[([^|\[\]]+?)\|([^|\[\]]+?)\]\]~';
 const REGEXP_PIPED_WIKILINK_ONLY = '~^\[\[([^|\[\]]+?)\|([^|\[\]]+?)\]\]$~';
-/** regexp for replacing to ndashes using mb_ereg_replace */
-const REGEXP_TO_EN_DASH = "--?|\&mdash;|\xe2\x80\x94|\?\?\?";
-/** regexp for replacing to ndashes using mb_ereg_replace */
+/** regexp for replacing to ndashes using preg_replace */
+const REGEXP_TO_EN_DASH = "~--?|&mdash;|\xe2\x80\x94|\?\?\?~u";
+/** regexp for replacing to ndashes using preg_replace */
 const REGEXP_EN_DASH = "\xe2\x80\x93";
 
 const REGEXP_BIBCODE = '~^https?://(?:(?:\w+.)?adsabs\.harvard\.edu|ads\.ari\.uni-heidelberg\.de|ads\.inasan\.ru|ads\.mao\.kiev\.ua|ads\.astro\.puc\.cl|ads\.on\.br|ads\.nao\.ac\.jp|ads\.bao\.ac\.cn|ads\.iucaa\.ernet\.in|ads\.lipi\.go\.id|cdsads\.u-strasbg\.fr|esoads\.eso\.org|ukads\.nottingham\.ac\.uk|www\.ads\.lipi\.go\.id)/.*(?:abs/|bibcode=|query\?|full/)([12]\d{3}[\w\d\.&]{15})~';


### PR DESCRIPTION
Replaces all deprecated mb_ereg* functions across the codebase with their PCRE preg_* equivalents, addressing PHP 8.4+ deprecation warnings.

Changes by file:

- regular_expressions.php - Added PCRE delimiters (~...~u) to REGEXP_TO_EN_DASH constant and updated its doc comment
- NameTools.php - Replaced mb_ereg_replace with preg_replace (line 99) and str_replace (line 116)
- Template.php - Replaced mb_ereg to preg_match and mb_ereg_replace to preg_replace for dash normalization (lines 5817-5820)
- TextTools.php - Replaced mb_ereg_search_init/mb_ereg_search_regs loop with preg_replace_callback in mb_ucwords()
- URLtools.php - Added missing :void return type on closure per Psalm

Follow-up commits apply consistent PCRE delimiter style and add null-safety (null coalescing fallback) for preg_replace_callback return type.