### PR TITLE
Remove unsupported open-access parameter per bug report

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -3148,6 +3148,13 @@ final class Template
                 $p->param = preg_replace('~(?:forename|initials?)\-?_?(\d+)~', "first$1", $p->param);
                 $p->param = preg_replace('~[\r\n]+~u', ' ', $p->param); // Have to be unicode safe
 
+                // Remove unsupported open-access parameter per bug report
+                if ($p->param === 'open-access') {
+                    report_forget("Removing unsupported open-access parameter");
+                    $this->quietly_forget($p->param);
+                    continue;
+                }
+
                 // Check the parameter list to find a likely replacement
                 $shortest = -1.0;
                 $closest = '';

--- a/tests/phpunit/includes/ConstantsTest.php
+++ b/tests/phpunit/includes/ConstantsTest.php
@@ -258,7 +258,7 @@ final class ConstantsTest extends testBaseClass {
                 $text
             ); // Stuff that gets "fixed"
             $text = str_replace([
-                '| doi-access = Z123Z ', '| access-date = Z123Z ', '| accessdate = Z123Z ', '| doi-broken = Z123Z ', '| doi-broken-date = Z123Z ', '| doi-inactive-date = Z123Z ', '| pmc-embargo-date = Z123Z ', '| embargo = Z123Z ', '| arşivengelli = Z123Z '],
+                '| doi-access = Z123Z ', '| access-date = Z123Z ', '| accessdate = Z123Z ', '| doi-broken = Z123Z ', '| doi-broken-date = Z123Z ', '| doi-inactive-date = Z123Z ', '| pmc-embargo-date = Z123Z ', '| embargo = Z123Z ', '| arşivengelli = Z123Z ', '| open-access = Z123Z '],
                 '',
                 $text
             );

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1944,6 +1944,19 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
+    public function testOpenAccessRemoved(): void {
+        $text = '{{cite journal|title=Test|doi=10.1234/example|open-access=yes}}';
+        $template = $this->process_citation($text);
+        $this->assertNull($template->get2('open-access'));
+        $this->assertNull($template->get2('osti-access'));
+    }
+
+    public function testOpenAccessRemovedWithoutDoi(): void {
+        $text = '{{cite journal|title=Test|open-access=yes}}';
+        $template = $this->process_citation($text);
+        $this->assertNull($template->get2('open-access'));
+    }
+
     private function tidy_issue(string $text): Template {
         $template = $this->make_citation($text);
         $template->tidy_parameter('issue');


### PR DESCRIPTION
When encountering |open-access=yes, the bot was Levenshtein-matching it to |osti-access=yes, which creates CS1/CS2 errors (yes is not a valid value for osti-access, and it requires matching |osti=).

Fixes: https://en.wikipedia.org/wiki/User_talk:Citation_bot#improper_replacement_of_unsupported_parameter