### PR TITLE
fix: purge BAD_WORK_NAMES from journal/periodical, expand URL detecti…

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4447,7 +4447,13 @@ final class Template
                         $this->forget($param);
                         return;
                     }
-                    if (preg_match('~^(|[a-zA-Z0-9][a-zA-Z0-9]+\.)([a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]+)\.(org|net|com)$~', $this->get($param))) {
+                    foreach (BAD_WORK_NAMES as $bad_name) {
+                        if (mb_strtolower(mb_trim(str_replace(['[[', ']]'], '', $this->get($param)))) === $bad_name) {
+                            $this->forget($param);
+                            return;
+                        }
+                    }
+                    if (preg_match('~^(|[a-zA-Z0-9][a-zA-Z0-9]+\.)*([a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]+)\.(org|net|com|gov|edu)$~', $this->get($param))) {
                         $this->rename($param, 'website');
                         return;
                     }
@@ -5515,7 +5521,7 @@ final class Template
 
                 case 'work':
                     foreach (BAD_WORK_NAMES as $bad_name) {
-                        if (mb_strtolower(mb_trim($this->get($param))) === $bad_name) {
+                        if (mb_strtolower(mb_trim(str_replace(['[[', ']]'], '', $this->get($param)))) === $bad_name) {
                             $this->forget($param);
                             return;
                         }
@@ -5947,7 +5953,7 @@ final class Template
                         return;
                     }
                     foreach (BAD_WORK_NAMES as $bad_name) {
-                        if (mb_strtolower(mb_trim($this->get($param))) === $bad_name) {
+                        if (mb_strtolower(mb_trim(str_replace(['[[', ']]'], '', $this->get($param)))) === $bad_name) {
                             $this->forget($param);
                             return;
                         }

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2479,4 +2479,68 @@ final class TemplatePart2Test extends testBaseClass {
         $this->assertSame('120–129', $template->get2('pages'));
     }
 
+    public function testTidyJournalPMC(): void {
+        $text = '{{cite journal|journal=PMC|pmc=9772900}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyJournalPubMed(): void {
+        $text = '{{cite journal|journal=PubMed|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyJournalWikiLinkedNIH(): void {
+        $text = '{{cite journal|journal=[[National Institutes of Health]]|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyJournalWikiLinkedNLM(): void {
+        $text = '{{cite journal|journal=[[National Library of Medicine]]|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyJournalPubMedCentral(): void {
+        $text = '{{cite journal|journal=PubMed Central|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyJournalPubmedDomainToWebsite(): void {
+        $text = '{{cite journal|journal=Pubmed.ncbi.NLM.nih.gov|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+        $this->assertSame('Pubmed.ncbi.NLM.nih.gov', $template->get2('website'));
+    }
+
+    public function testTidyJournalNIH(): void {
+        $text = '{{cite journal|journal=NIH|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('journal'));
+    }
+
+    public function testTidyWorkWikiLinkedPubMed(): void {
+        $text = '{{cite journal|work=[[PubMed]]|pmid=12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('work'));
+    }
+
+    public function testTidyWebsiteWikiLinkedPMC(): void {
+        $text = '{{cite journal|website=[[PMC]]|pmc=PMC12345}}';
+        $template = $this->make_citation($text);
+        $template->tidy();
+        $this->assertNull($template->get2('website'));
+    }
+
 }


### PR DESCRIPTION
## Bug

Fixes the remaining cases from bug report campaign Stage 1+2 (PR #5606) where journal/periodical parameters with database/website names were not being purged during tidy.

PR #5606 added BAD_WORK_NAMES checks to the `work` and `website` tidy cases but missed `journal` and `periodical`, leaving these values uncleaned:

| Input | Status |
|---|---|
| `journal=PMC` | Not caught |
| `journal=[[National Institutes of Health]]` | Not caught (wiki-linked) |
| `journal=[[National Library of Medicine]]` | Not caught (wiki-linked) |
| `journal=Pubmed.ncbi.NLM.nih.gov` | Not caught (domain-like, TLD not matched) |

## Changes

### src/includes/Template.php
1. Added BAD_WORK_NAMES check to `journal`/`periodical` tidy case with `[[`/`]]` bracket stripping
2. Expanded URL domain regex from `\.(org|net|com)` to `\.(org|net|com|gov|edu)` with multi-subdomain (`*`) support to catch domain-like journal values like `Pubmed.ncbi.NLM.nih.gov`
3. Added wiki-bracket stripping to existing `work` BAD_WORK_NAMES check (defensive)
4. Added wiki-bracket stripping to existing `website` BAD_WORK_NAMES check (defensive)

### tests/phpunit/includes/TemplatePart2Test.php
Added 9 tests covering all fixed cases. All 79 tidy/fix tests pass (70 existing + 9 new) with 0 regressions.