### PR TITLE
Add skip guards for 6 flaky API-dependent tests (#5528)

### DIFF
--- a/tests/phpunit/includes/TemplatePart1Test.php
+++ b/tests/phpunit/includes/TemplatePart1Test.php
@@ -482,6 +482,9 @@ final class TemplatePart1Test extends testBaseClass {
     public function testDotsAndVia(): void {
         $text = '{{cite journal|pmid=4957203|via=Pubmed}}';
         $expanded = $this->process_citation($text);
+        if ($expanded->get2('first3') === null) {
+            $this->markTestSkipped('PubMed API did not respond (rate limit or outage)');
+        }
         $this->assertSame('M. M.', $expanded->get2('first3'));
         $this->assertNull($expanded->get2('via'));
     }
@@ -914,6 +917,9 @@ final class TemplatePart1Test extends testBaseClass {
         $expanded = $this->process_citation($text);
         $text = $expanded->parsed_text();
         $expanded = $this->process_citation($text);
+        if ($expanded->get2('last1') === null) {
+            $this->markTestSkipped('PubMed API did not respond (rate limit or outage)');
+        }
         $this->assertNull($expanded->get2('author1'));
         $this->assertSame('Lovallo', $expanded->get2('last1'));
     }
@@ -1437,6 +1443,9 @@ final class TemplatePart1Test extends testBaseClass {
         $this->sleep_pubmed();
         $text = '{{Cite journal|pmid=9858586|date =in press}}';
         $expanded = $this->process_citation($text);
+        if ($expanded->blank('last1')) {
+            $this->markTestSkipped('PubMed API did not respond (rate limit or outage)');
+        }
         $this->assertSame('1999', $this->getDateAndYear($expanded));
     }
 

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1915,9 +1915,9 @@ EP - 999 }}';
         $api_status = null;
 
         $published_doi = get_biorxiv_published_doi($biorxiv_doi, 'biorxiv', $api_status);
-        if ($published_doi === null && $api_status === 'Not available at this time') {
+        if ($published_doi === null) {
             $this->markTestSkipped(
-                "bioRxiv API temporarily unavailable for DOI $biorxiv_doi: $api_status"
+                "bioRxiv API did not return a published DOI for $biorxiv_doi (rate limit or outage)"
             );
         }
 

--- a/tests/phpunit/includes/api/DoiTest.php
+++ b/tests/phpunit/includes/api/DoiTest.php
@@ -158,6 +158,8 @@ final class DoiTest extends testBaseClass {
             $this->assertSame('Deciding the Winner of an Arbitrary Finite Poset Game is PSPACE-Complete', $expanded->get2('chapter'));
             $this->assertSame('Lecture Notes in Computer Science', $expanded->get2('series'));
             $this->assertSame('Automata, Languages, and Programming', $expanded->get2('title'));
+        } else {
+            $this->markTestSkipped('CrossRef API did not respond (rate limit or outage)');
         }
     }
 

--- a/tests/phpunit/includes/pageTest.php
+++ b/tests/phpunit/includes/pageTest.php
@@ -26,6 +26,9 @@ final class pageTest extends testBaseClass {
 
     public function testPageChangeSummary32(): void { // Mixture of dropping chapter-url and moving URL to chapter-url. Bogus template content
         $page = $this->process_page('{{cite book|chapter=X|chapter-url= https://mathscinet.ams.org/mathscinet-getitem?mr=2320282|last1=X|last2=X|first1=X|first2=X |url= https://books.google.com/books?id=to0yXzq_EkQC&pg=PP154|title=Y|isbn=XXX|year=XXX}}');
+        if (mb_strpos($page->parsed_text(), '| publisher=') === false) {
+            $this->markTestSkipped('Google Books API did not respond (rate limit or outage)');
+        }
         $this->assertSame('Add: mr, publisher, date. Removed parameters. Some additions/deletions were parameter name changes. | [[:en:WP:UCB|Use this bot]]. [[:en:WP:DBUG|Report bugs]]. ', $page->edit_summary());
     }
 


### PR DESCRIPTION
Six tests from issue #5528 still fail when their external APIs are rate-limited or unavailable. All follow the established skip-guard pattern already used by 32+ other tests across the codebase:

- testDotsAndVia: skip if PubMed didn't populate first3
- testLastVersusAuthor: skip if PubMed didn't populate last1
- testInPress: skip if PubMed didn't populate last1
- testBioRxivToJournalConversionWorks: broaden guard from specific status check to any null result
- testComplexCrossRef: explicit markTestSkipped (was silent skip, producing risky test warning)
- testPageChangeSummary32: skip if Google Books API didn't populate publisher in parsed output