### PR TITLE
fix: revert cite arxiv to cite journal when PubMed returns 'ArXiv' as  journal name

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -6291,10 +6291,16 @@ final class Template
                     $this->tidy_parameter('publisher');
                 }
             }
-            if ($this->wikiname() === 'cite journal' && $this->blank(WORK_ALIASES) && mb_stripos($this->initial_name, 'journal') === false) {
+            if ($this->wikiname() === 'cite journal' && mb_stripos($this->initial_name, 'journal') === false) {
                 if ($this->has('arxiv') || $this->has('eprint')) {
-                    $this->change_name_to('cite arxiv');
-                } else {
+                    $arxiv_journal = $this->has('journal') && mb_stripos($this->get('journal'), 'arxiv') !== false;
+                    if ($this->blank(WORK_ALIASES) || $arxiv_journal) {
+                        if ($arxiv_journal) {
+                            $this->forget('journal');
+                        }
+                        $this->change_name_to('cite arxiv');
+                    }
+                } elseif ($this->blank(WORK_ALIASES)) {
                     $this->change_name_to($this->initial_name);
                 }
             }

--- a/src/includes/miscTools.php
+++ b/src/includes/miscTools.php
@@ -652,7 +652,7 @@ function handleConferencePretendingToBeAJournal(Template $template, string $rawt
             $the_journal = '';
             $bad_data = true;
         }
-        if ((mb_stripos($the_journal, 'arXiv:') === 0 || $the_journal === 'arXiv') && !$template->blank(ARXIV_ALIASES)) {
+        if ((mb_stripos($the_journal, 'arXiv:') === 0 || str_i_same($the_journal, 'arXiv')) && !$template->blank(ARXIV_ALIASES)) {
             $template->forget('journal');
             $the_journal = '';
             $bad_data = true;


### PR DESCRIPTION

## Summary

Fixes a bug where Citation Bot converts `{{cite arxiv}}` to `{{cite journal}}` with `journal=Arxiv` when PubMed returns `FullJournalName=ArXiv` for a preprint that hasn't been published in a peer-reviewed journal.

## Root Cause

The bot's arXiv-journal cleanup in `handleConferencePretendingToBeAJournal()` runs during Phase 1 (`prepare()`), before PubMed adds the journal in Phase 3. By the time `final_tidy()` runs in Phase 4, the journal `ArXiv` is already set, but the existing revert-to-`cite-arxiv` logic at `Template.php:6294` skips it because `journal=ArXiv` makes `blank(WORK_ALIASES)` return false.

## Changes

### Fix A: `Template.php:6294`
Extends the `final_tidy()` revert-to-`cite-arxiv` logic to also handle journals containing 'arxiv' (case-insensitive). When a `cite journal` has an arxiv/eprint ID, was not originally a `cite journal`, and its journal name contains 'arxiv', the bot now forgets the arXiv journal and reverts to `cite arxiv`.

### Fix B: `miscTools.php:655`
Changes the exact case-sensitive comparison `$the_journal === 'arXiv'` to case-insensitive `str_i_same($the_journal, 'arXiv')` so pre-existing `journal=ArXiv` in templates at Phase 1 is also caught.

## Verification

- Existing arXiv-journal tests pass (testAllSortsOfBadData, testFinalTidyThings, testCleanArxivDOI)
- Manual tests confirm all three edge cases:
  - **Bug scenario** (`cite arxiv` + PubMed `ArXiv` journal): correctly reverts to `cite arxiv`, forgets journal
  - **Real journal** (`cite arxiv` + PubMed `Physical Review Letters`): correctly stays as `cite journal`
  - **Originally `cite journal`** with `journal=Arxiv`: correctly unchanged (`initial_name` check)
- Pre-existing API-dependent test failures (testCAPSGoingAway) confirmed unchanged via `git stash`