### PR TITLE
recognize emerald.com URLs as chapter-urls 

### DIFF
--- a/src/includes/miscTools.php
+++ b/src/includes/miscTools.php
@@ -352,6 +352,9 @@ function should_url2chapter(Template $template, bool $force): bool {
     if (mb_stripos($url, 'taylorfrancis.com/chapters/') !== false) {
         return true;
     }
+    if ((mb_stripos($url, 'emerald.com') !== false || mb_stripos($url, 'emeraldinsight.com') !== false) && mb_stripos($url, '/chapter-') !== false) {
+        return true;
+    }
     return false;
 }
 

--- a/tests/phpunit/includes/MiscToolsTest.php
+++ b/tests/phpunit/includes/MiscToolsTest.php
@@ -414,6 +414,11 @@ final class MiscToolsTest extends testBaseClass {
         $this->assertTrue($template->has('chapter-url'));
     }
 
+    public function testShouldUrl2ChapterEmerald(): void {
+        $template = $this->make_citation('{{cite book |chapter=Test |url=https://www.emerald.com/books/chapter-abstract/123}}');
+        $this->assertTrue(should_url2chapter($template, false));
+    }
+
     public function testRunTypeModsReturnsInt(): void {
         $result = run_type_mods(-1, 10, 20, 30, 40);
         $this->assertIsInt($result);


### PR DESCRIPTION
## Summary

Fixes [(https://en.wikipedia.org/wiki/User_talk:Citation_bot#Emerald_Chapter-url_recognition)
— when a `{{cite book}}` has a `chapter` parameter and the URL points to an emerald.com or emeraldinsight.com chapter page, the bot now converts `url=` to `chapter-url=`.

## Changes

- **src/includes/miscTools.php** — Added emerald.com/emeraldinsight.com check  to `should_url2chapter()`. Requires both the domain and `/chapter-` in th  URL path (matching their `/chapter-abstract/` convention), avoiding false positives on non-chapter emerald pages.
- **tests/phpunit/includes/MiscToolsTest.php** — Added  `testShouldUrl2ChapterEmerald`.


