### PR TITLE
Migrate CI from ubuntu-22.04 to ubuntu-24.04 and switch actionlint 

### DIFF
--- a/.github/workflows/DesignSecurity.yml
+++ b/.github/workflows/DesignSecurity.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/PHPChecker.yml
+++ b/.github/workflows/PHPChecker.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/PHPCodeSniffer.yml
+++ b/.github/workflows/PHPCodeSniffer.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/ThePHPChecker.yml
+++ b/.github/workflows/ThePHPChecker.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,16 +13,11 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v7.0.0
 
-    - name: Download actionlint v1.7.12
-      run: |
-        curl -sSLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
-        tar xzf actionlint_1.7.12_linux_amd64.tar.gz
-
     - name: Run actionlint
-      run: ./actionlint -color
+      uses: rhysd/actionlint-action@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/html5check.yml
+++ b/.github/workflows/html5check.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/labeler@v6

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lychee:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,7 +64,7 @@ concurrency:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo


### PR DESCRIPTION
## Changes

- **Ubuntu 22.04 → 24.04:** Updated `runs-on` in 15 workflow files. Ubuntu 22.04 is deprecated and will be removed by GitHub.
- **Actionlint:** Replaced manual tarball download with `rhysd/actionlint-action@v1` — auto-downloads latest version, handles caching.
- 3 workflows (`codeql-analysis.yml`, `trivy-analysis.yml`, `YamlJson.yml`) were already on `ubuntu-latest` and left untouched.

## Verification

- No `ubuntu-22.04` references remain across any workflow files.
- Commit: `982e0d1b`