### PR TITLE
Remove dead/unused code blocks

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -2351,9 +2351,6 @@ final class Template
                 // We want to make sure we understand what we are adding - sometimes we find odd floating parameters
                 // @codeCoverageIgnoreStart
                 report_minor_error('Unexpected parameter: ' . echoable($param_name) . ' trying to be set to ' . echoable($value));
-                // if ($this->blank($param_name)) {
-                //  return $this->add($param_name, sanitize_string($value));
-                // }
                 return false;
             // @codeCoverageIgnoreEnd
         }
@@ -6550,19 +6547,6 @@ final class Template
                         $this->forget($worky);
                     }
                 }
-                /*
-                // If one and only one work alias is set, the move it to publisher
-                if ($this->blank('publisher')) {
-                    $counting = 0;
-                    foreach (WORK_ALIASES as $worky) {
-                    if ($this->has($worky)) $counting = $counting + 1;
-                }
-                if ($counting === 1) {
-                    foreach (WORK_ALIASES as $worky) {
-                        //TODO: convert to via/publisher/delete/log depending upon specificsif ($this->has($worky)) bot_debug_log('WORKY ' . $this->get($worky));
-                    }
-                }
-                */
             } elseif ($this->has('publisher')) {
                 foreach (WORK_ALIASES as $worky) {
                     if (mb_strtolower($this->get('publisher')) === mb_strtolower($this->get($worky))) {

--- a/src/includes/TextTools.php
+++ b/src/includes/TextTools.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/constants.php';     // @codeCoverageIgnore
 require_once __DIR__ . '/Template.php';      // @codeCoverageIgnore
-require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
 
 const MONTH_SEASONS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December', 'Winter', 'Spring', 'Summer', 'Fall', 'Autumn'];
 const DAYS_OF_WEEKS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'Mony', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat', 'Sun'];

--- a/src/includes/URLtools.php
+++ b/src/includes/URLtools.php
@@ -2035,9 +2035,6 @@ function find_identifiers_in_urls_INSIDE(Template $template, string $url, string
             if ($template->blank('mr')) {
                 report_modification("Converting URL to MR parameter");
             }
-            //if (!$url_sent) {
-            //    $template->forget($url_type); // This points to a review and not the article
-            //}
             return $template->add_if_new('mr', $match[1]);
         } elseif (preg_match("~^https?://(?:www\.|)papers\.ssrn\.com(?:/sol3/papers\.cfm\?abstract_id=|/abstract=)([0-9]+)~i", $url, $match)) {
             if ($template->blank('ssrn')) {

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/big_jobs.php';      // @codeCoverageIgnore
+
 /**
  * Only on webpage
  */

--- a/src/includes/api/APIzotero.php
+++ b/src/includes/api/APIzotero.php
@@ -725,9 +725,6 @@ final class Zotero {
                 $result->extra = mb_trim(str_replace(mb_trim($matches[0]), '', $result->extra));      // @codeCoverageIgnore
             }
             $result->extra = mb_trim($result->extra);
-            if ($result->extra !== '') {
-                // TODO - check back later on report_minor_error("Unhandled extra data: " . echoable($result->extra) .  ' FROM ' . echoable($url));     // @codeCoverageIgnore
-            }
         }
 
         if (isset($result->DOI) && $template->blank('doi')) {


### PR DESCRIPTION
## Summary

Removes 23 lines of dead/unused code across 5 files:

- **TextTools.php**: Remove redundant `require_once __DIR__ . '/big_jobs.php'` — moved to WebTools.php where functions are actually consumed
- **WebTools.php**: Add `require_once __DIR__ . '/big_jobs.php'` — WebTools is the actual consumer of `big_jobs_check_overused()` and `big_jobs_check_killed()`
- **Template.php**: Remove 2 commented-out code blocks — abandoned work-alias-to-publisher feature and old `add_if_new()` default-case (blindly adding unknown params)
- **URLtools.php**: Remove 3 commented-out lines for MathSciNet URL forgetting (tests assert the opposite — URL is preserved)
- **APIzotero.php**: Remove empty `if` block — 10-year-old TODO no-op (`$result->extra !== ''` with only a commented-out `report_minor_error` inside)
