### PR TITLE
Use clean DOI value for free-DOI prefix check

### DIFF
--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4297,7 +4297,7 @@ final class Template
                     }
                     /** if (doi_works($doi)) { We are flagging free dois even when the do not work, since template does this right now */
                     foreach (DOI_FREE_PREFIX as $prefix) {
-                        if (mb_stripos($doi, $prefix) === 0) {
+                        if (mb_stripos($this->get_without_comments_and_placeholders('doi'), $prefix) === 0) {
                             $this->add_if_new('doi-access', 'free');
                         }
                     }

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -2029,4 +2029,32 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $template->handle_et_al();
         $this->assertSame('etal', $template->get2('display-authors'));
     }
+
+    public function testDoiPrefixFreeDetected(): void {
+        $text = '{{cite journal|doi=10.1186/s12915-020-00940-y}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiPrefixFreeWithComment(): void {
+        $text = '{{cite journal|doi=<!-- comment -->10.1186/s12915-020-00940-y}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiPrefixFreeWithTrailingNewline(): void {
+        $text = "{{cite journal|doi=10.1186/s12915-020-00940-y\n}}";
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertSame('free', $template->get2('doi-access'));
+    }
+
+    public function testDoiPrefixNonFreeNotDetected(): void {
+        $text = '{{cite journal|doi=10.1234/nonfree-example}}';
+        $template = $this->make_citation($text);
+        $template->tidy_parameter('doi');
+        $this->assertNull($template->get2('doi-access'));
+    }
 }


### PR DESCRIPTION
Replaced  (raw value with placeholders) with
get_without_comments_and_placeholders('doi') (resolved value) in the DOI_FREE_PREFIX check. This allows the free-DOI detection to work when the DOI parameter contains a {{doi|...}} or {{doi-inline|...}} template that resolved to the DOI string.

Previously, if doi={{doi|10.1186/xxx}} was used in a citation, the raw DOI value contained template placeholders which would not match the free-DOI prefix list. The resolved value from get_without_comments_and_placeholders() returns the actual DOI.