### PR TITLE
Resolve {{doi|...}} template placeholders for free-DOI prefix check

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -365,6 +365,12 @@ class Page {
         $our_templates_slight = [];
         /** @var array<Template> $our_templates_conferences */
         $our_templates_conferences = [];
+        // Tag standalone {{doi}} and {{doi-inline}} templates with free-DOI access
+        foreach ($all_templates as $this_template) {
+            if (in_array($this_template->wikiname(), ['doi', 'doi-inline'], true)) {
+                $this_template->set_free_doi_access();
+            }
+        }
         report_phase('Remedial work to prepare citations');
         foreach ($all_templates as $this_template) {
             set_time_limit(120);

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4096,16 +4096,6 @@ final class Template
                     if (!$doi) {
                         return;
                     }
-                    if (preg_match('~# # # CITATION_BOT_PLACEHOLDER_TEMPLATE (\d+) # # #~i', $doi, $m)) {
-                        $idx = (int) $m[1];
-                        if (isset(self::$all_templates[$idx]) && in_array(self::$all_templates[$idx]->wikiname(), ['doi', 'doi-inline'], true)) {
-                            $resolved = self::$all_templates[$idx]->param_value(0);
-                            if ($resolved !== '') {
-                                $doi = $resolved;
-                                $this->set('doi', $doi);
-                            }
-                        }
-                    }
                     if ($this->wikiname() === 'cite journal') {
                         if (mb_stripos($doi, '10.2307/j.') === 0 || preg_match('~^10\.\d+/\d+\.ch\d+$~', $doi)) {
                             $this->change_name_to('cite book');
@@ -7108,6 +7098,19 @@ final class Template
             return $this->param[$i]->val;
         }
         return '';
+    }
+
+    /** For {{doi}}/{{doi-inline}} templates: add doi-access=free if DOI matches a free prefix */
+    public function set_free_doi_access(): void {
+        $doi = $this->param_value(0);
+        if ($doi !== '') {
+            foreach (DOI_FREE_PREFIX as $prefix) {
+                if (mb_stripos($doi, $prefix) === 0) {
+                    $this->set('doi-access', 'free');
+                    break;
+                }
+            }
+        }
     }
 
     public function get_without_comments_and_placeholders(string $name): string {

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -4096,6 +4096,16 @@ final class Template
                     if (!$doi) {
                         return;
                     }
+                    if (preg_match('~# # # CITATION_BOT_PLACEHOLDER_TEMPLATE (\d+) # # #~i', $doi, $m)) {
+                        $idx = (int) $m[1];
+                        if (isset(self::$all_templates[$idx]) && in_array(self::$all_templates[$idx]->wikiname(), ['doi', 'doi-inline'], true)) {
+                            $resolved = self::$all_templates[$idx]->param_value(0);
+                            if ($resolved !== '') {
+                                $doi = $resolved;
+                                $this->set('doi', $doi);
+                            }
+                        }
+                    }
                     if ($this->wikiname() === 'cite journal') {
                         if (mb_stripos($doi, '10.2307/j.') === 0 || preg_match('~^10\.\d+/\d+\.ch\d+$~', $doi)) {
                             $this->change_name_to('cite book');

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1955,40 +1955,25 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
-    public function testDoiTemplateFreePrefixDetected(): void {
+    public function testDoiFreePrefixDetected(): void {
         $doi_t = new Template();
         $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y}}');
-        $cite_t = new Template();
-        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
-        Template::$all_templates = [$doi_t];
-        $cite_t->tidy_parameter('doi');
-        $this->assertSame('10.1186/s12915-020-00940-y', $cite_t->get2('doi'));
-        $this->assertSame('free', $cite_t->get2('doi-access'));
-        Template::$all_templates = [];
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
     }
 
-    public function testDoiInlineTemplateFreePrefixDetected(): void {
+    public function testDoiInlineFreePrefixDetected(): void {
         $doi_t = new Template();
         $doi_t->parse_text('{{doi-inline|10.1186/s12915-020-00940-y|Title}}');
-        $cite_t = new Template();
-        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
-        Template::$all_templates = [$doi_t];
-        $cite_t->tidy_parameter('doi');
-        $this->assertSame('10.1186/s12915-020-00940-y', $cite_t->get2('doi'));
-        $this->assertSame('free', $cite_t->get2('doi-access'));
-        Template::$all_templates = [];
+        $doi_t->set_free_doi_access();
+        $this->assertSame('free', $doi_t->get2('doi-access'));
     }
 
-    public function testDoiTemplateNonFreePrefixNotDetected(): void {
+    public function testDoiNonFreePrefixNotDetected(): void {
         $doi_t = new Template();
         $doi_t->parse_text('{{doi|10.1234/nonfree-example}}');
-        $cite_t = new Template();
-        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
-        Template::$all_templates = [$doi_t];
-        $cite_t->tidy_parameter('doi');
-        $this->assertSame('10.1234/nonfree-example', $cite_t->get2('doi'));
-        $this->assertNull($cite_t->get2('doi-access'));
-        Template::$all_templates = [];
+        $doi_t->set_free_doi_access();
+        $this->assertNull($doi_t->get2('doi-access'));
     }
 
     public function testOpenAccessRemoved(): void {

--- a/tests/phpunit/includes/templatePart4Test.php
+++ b/tests/phpunit/includes/templatePart4Test.php
@@ -1955,6 +1955,42 @@ final class templatePart4Test extends testBaseClass { // Lower case "t" to run l
         $this->assertNull($template->get2('doi-access'));
     }
 
+    public function testDoiTemplateFreePrefixDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1186/s12915-020-00940-y}}');
+        $cite_t = new Template();
+        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
+        Template::$all_templates = [$doi_t];
+        $cite_t->tidy_parameter('doi');
+        $this->assertSame('10.1186/s12915-020-00940-y', $cite_t->get2('doi'));
+        $this->assertSame('free', $cite_t->get2('doi-access'));
+        Template::$all_templates = [];
+    }
+
+    public function testDoiInlineTemplateFreePrefixDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi-inline|10.1186/s12915-020-00940-y|Title}}');
+        $cite_t = new Template();
+        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
+        Template::$all_templates = [$doi_t];
+        $cite_t->tidy_parameter('doi');
+        $this->assertSame('10.1186/s12915-020-00940-y', $cite_t->get2('doi'));
+        $this->assertSame('free', $cite_t->get2('doi-access'));
+        Template::$all_templates = [];
+    }
+
+    public function testDoiTemplateNonFreePrefixNotDetected(): void {
+        $doi_t = new Template();
+        $doi_t->parse_text('{{doi|10.1234/nonfree-example}}');
+        $cite_t = new Template();
+        $cite_t->parse_text('{{cite journal|doi=# # # CITATION_BOT_PLACEHOLDER_TEMPLATE 0 # # #}}');
+        Template::$all_templates = [$doi_t];
+        $cite_t->tidy_parameter('doi');
+        $this->assertSame('10.1234/nonfree-example', $cite_t->get2('doi'));
+        $this->assertNull($cite_t->get2('doi-access'));
+        Template::$all_templates = [];
+    }
+
     public function testOpenAccessRemoved(): void {
         $text = '{{cite journal|title=Test|doi=10.1234/example|open-access=yes}}';
         $template = $this->process_citation($text);


### PR DESCRIPTION
When a citation uses doi={{doi|10.1186/xxx}} or doi={{doi-inline|10.1186/xxx}}, the template parser extracts the inner template as a subtemplate and puts a placeholder in the citation's doi parameter. The free-DOI prefix check was checking the raw placeholder string which never matches the prefix list.

This fix resolves the placeholder by looking up the referenced subtemplate in Template:: and extracting the actual DOI from it before performing the free-DOI prefix check. Also handles {{doi-inline|...}}.