### PR TITLE
Protect <syntaxhighlight> blocks from template processing

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -231,6 +231,8 @@ class Page {
         $musicality = $this->extract_object('Musicscores');
         /** @var array<Preformated> $preformated */
         $preformated = $this->extract_object('Preformated');
+        /** @var array<SyntaxHighlight> $syntaxhighlights */
+        $syntaxhighlights = $this->extract_object('SyntaxHighlight');
         set_time_limit(120);
         if (!$this->allow_bots()) {
             report_warning("Page marked with {{nobots}} template.    Skipping.");

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -231,8 +231,7 @@ class Page {
         $musicality = $this->extract_object('Musicscores');
         /** @var array<Preformated> $preformated */
         $preformated = $this->extract_object('Preformated');
-        /** @var array<SyntaxHighlight> $syntaxhighlights */
-        $syntaxhighlights = $this->extract_object('SyntaxHighlight');
+        $this->extract_object('SyntaxHighlight');
         set_time_limit(120);
         if (!$this->allow_bots()) {
             report_warning("Page marked with {{nobots}} template.    Skipping.");

--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -231,7 +231,8 @@ class Page {
         $musicality = $this->extract_object('Musicscores');
         /** @var array<Preformated> $preformated */
         $preformated = $this->extract_object('Preformated');
-        $this->extract_object('SyntaxHighlight');
+        /** @var array<SyntaxHighlight> $syntaxhighlights */
+        $syntaxhighlights = $this->extract_object('SyntaxHighlight');
         set_time_limit(120);
         if (!$this->allow_bots()) {
             report_warning("Page marked with {{nobots}} template.    Skipping.");
@@ -591,6 +592,8 @@ class Page {
         unset($triplebrack);
         $this->replace_object($preformated);
         unset($preformated);
+        $this->replace_object($syntaxhighlights);
+        unset($syntaxhighlights);
         $this->replace_object($musicality);
         unset($musicality);
         $this->replace_object($mathematics);

--- a/src/includes/WikiThings.php
+++ b/src/includes/WikiThings.php
@@ -51,6 +51,11 @@ final class Preformated extends WikiThings {
     public const array REGEXP = ['~<pre>[\s\S]*?</pre>~us'];
 }
 
+final class SyntaxHighlight extends WikiThings {
+    public const string PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_SYNTAXHIGHLIGHT %s # # #';
+    public const array REGEXP = ['~<syntaxhighlight[^>]*>[\s\S]*?</syntaxhighlight>~usi'];
+}
+
 final class SingleBracket extends WikiThings {
     public const string PLACEHOLDER_TEXT = '# # # CITATION_BOT_PLACEHOLDER_SINGLE_BRACKET %s # # #';
     public const array REGEXP = ['~(?<!\{)\{[^\{\}]+\}(?!\})~us'];

--- a/tests/phpunit/includes/WikiThingsTest.php
+++ b/tests/phpunit/includes/WikiThingsTest.php
@@ -178,4 +178,44 @@ final class WikiThingsTest extends testBaseClass {
         $comment->parse_text('');
         $this->assertSame('', $comment->parsed_text());
     }
+
+    public function testSyntaxHighlightParseAndReturn(): void {
+        $sh = new SyntaxHighlight();
+        $sh->parse_text('<syntaxhighlight lang="wikitext">{{doi|10.1080/xxx}}</syntaxhighlight>');
+        $this->assertSame('<syntaxhighlight lang="wikitext">{{doi|10.1080/xxx}}</syntaxhighlight>', $sh->parsed_text());
+    }
+
+    public function testSyntaxHighlightPlaceholderContainsKey(): void {
+        $this->assertStringContainsString('CITATION_BOT_PLACEHOLDER_SYNTAXHIGHLIGHT', SyntaxHighlight::PLACEHOLDER_TEXT);
+    }
+
+    public function testSyntaxHighlightRegexpMatchesBasic(): void {
+        $text = '<syntaxhighlight>code example</syntaxhighlight>';
+        $this->assertMatchesRegularExpression(SyntaxHighlight::REGEXP[0], $text);
+    }
+
+    public function testSyntaxHighlightRegexpMatchesWithAttrs(): void {
+        $text = '<syntaxhighlight lang="wikitext" inline="1">{{doi|10.1080/xxx}}</syntaxhighlight>';
+        $this->assertMatchesRegularExpression(SyntaxHighlight::REGEXP[0], $text);
+    }
+
+    public function testSyntaxHighlightBlocksTemplateExtraction(): void {
+        $text = 'before <syntaxhighlight lang="wikitext">{{doi|10.1080/xxx}}</syntaxhighlight> after';
+        $page = new Page();
+        $page->parse_text($text);
+        // Extract SyntaxHighlights — this replaces them with placeholders
+        $syntaxhighlights = $page->extract_object('SyntaxHighlight');
+        $this->assertCount(1, $syntaxhighlights);
+        // After extracting SyntaxHighlights, the text should no longer contain the raw tag
+        $ref = new ReflectionClass($page);
+        $textProp = $ref->getProperty('text');
+        $textProp->setAccessible(true);
+        $protectedText = $textProp->getValue($page);
+        $this->assertStringNotContainsString('<syntaxhighlight', $protectedText);
+        // Extract Templates — the {{doi|...}} inside syntaxhighlight should NOT be extracted
+        Template::$all_templates = [];
+        $templates = $page->extract_object('Template');
+        $this->assertCount(0, $templates, 'No templates should be extracted from inside syntaxhighlight blocks');
+        Template::$all_templates = [];
+    }
 }

--- a/tests/phpunit/includes/WikiThingsTest.php
+++ b/tests/phpunit/includes/WikiThingsTest.php
@@ -209,7 +209,6 @@ final class WikiThingsTest extends testBaseClass {
         // After extracting SyntaxHighlights, the text should no longer contain the raw tag
         $ref = new ReflectionClass($page);
         $textProp = $ref->getProperty('text');
-        $textProp->setAccessible(true);
         $protectedText = $textProp->getValue($page);
         $this->assertStringNotContainsString('<syntaxhighlight', $protectedText);
         // Extract Templates — the {{doi|...}} inside syntaxhighlight should NOT be extracted


### PR DESCRIPTION
Adds SyntaxHighlight class to WikiThings.php that extracts <syntaxhighlight>...</syntaxhighlight> content and replaces it with placeholders before template extraction. This prevents the bot from processing {{doi}} and other templates inside code examples.

Also adds the extract_object('SyntaxHighlight') call in Page::expand_text() before template extraction.