### PR TITLE
Feature/article number detection

### DIFF
--- a/src/includes/Page.php
+++ b/src/includes/Page.php
@@ -767,6 +767,12 @@ class Page {
         if ($this->modifications["issue_citebook"]) {
             $auto_summary .= 'Removed unsupported issue parameter from cite book. ';
         }
+        if ($this->modifications["article_number"]) {
+            $auto_summary .= 'Converted page numbers to article numbers. ';
+        }
+        if ($this->modifications["article_number_iucn"]) {
+            $auto_summary .= 'Converted deprecated page parameter to article-number in cite IUCN. ';
+        }
         if ($this->odnb_sub_removed) {
             $auto_summary .= 'Removed ODNBsub template. ';
         }
@@ -1092,5 +1098,7 @@ class Page {
         $this->modifications['ref'] = false;
         $this->modifications['na'] = false;
         $this->modifications['issue_citebook'] = false;
+        $this->modifications['article_number'] = false;
+        $this->modifications['article_number_iucn'] = false;
     }
 }

--- a/src/includes/Template.php
+++ b/src/includes/Template.php
@@ -49,6 +49,8 @@ final class Template
     private bool $mod_ref = false;
     private bool $mod_na = false;
     private bool $mod_issue_citebook = false;
+    private bool $mod_article_number = false;
+    private bool $mod_article_number_iucn = false;
     private bool $no_initial_doi = false;
     private bool $held_work_done = false;
     /** @var array<array<string>> */
@@ -6173,6 +6175,9 @@ final class Template
 
     public function final_tidy(): void {
         set_time_limit(120);
+        // Run before should_be_processed() guard: cite IUCN is not in TEMPLATES_WE_PROCESS
+        // but its page->article-number rename still needs to run via detect_article_number()
+        $this->detect_article_number();
         if ($this->should_be_processed()) {
             if ($this->initial_name !== $this->name) {
                 $this->tidy();
@@ -6694,6 +6699,135 @@ final class Template
                 }
             }
         }
+    }
+
+    private function detect_article_number(): bool {
+        $name = $this->wikiname();
+
+        // Handle cite IUCN special case
+        if ($name === 'cite iucn') {
+            $page_val = $this->get('page') ?: $this->get('pages');
+            if ($page_val !== '' && preg_match('/^e\./i', $page_val)) {
+                if ($this->has('page')) {
+                    $this->rename('page', 'article-number');
+                } else {
+                    $this->rename('pages', 'article-number');
+                }
+                $this->mod_article_number_iucn = true;
+                report_action("Converted page to article-number in cite IUCN template");
+                return true;
+            }
+            return false;
+        }
+
+        // Only apply to cite journal, cite conference, or citation with journal/work
+        if (!in_array($name, ['cite journal', 'cite conference', 'citation'], true)) {
+            return false;
+        }
+        if ($name === 'citation' && $this->blank(['journal', 'work'])) {
+            return false;
+        }
+
+        // Need both page(s) and doi
+        if ($this->has('page') && !$this->blank('page')) {
+            $page_param = 'page';
+            $pages_value = $this->get('page');
+        } elseif ($this->has('pages') && !$this->blank('pages')) {
+            $page_param = 'pages';
+            $pages_value = $this->get('pages');
+        } else {
+            return false;
+        }
+        if ($this->blank('doi')) {
+            return false;
+        }
+
+        $pages_value = mb_trim($pages_value);
+        $doi_value = mb_trim($this->get('doi'));
+
+        // Skip if pages contains range/list characters
+        if (preg_match('/[,;_−–—‒%-]/u', $pages_value)) {
+            return false;
+        }
+
+        // Skip if pages contains URL
+        if (preg_match('/https?:\/\//i', $pages_value)) {
+            return false;
+        }
+
+        $doi_lower = mb_strtolower($doi_value);
+        $pages_lower = mb_strtolower($pages_value);
+
+        // Skip zootaxa false positive
+        if (str_contains($doi_lower, 'zootaxa') && str_contains($pages_lower, 'zootaxa')) {
+            return false;
+        }
+
+        // Skip DDI (Digital Document Identifier) false positive:
+        // Some DOIs contain "ddi" in their suffix which can match DDI-like page values
+        if (str_contains($doi_lower, 'ddi') && str_contains($pages_lower, 'ddi')) {
+            return false;
+        }
+
+        $match_found = false;
+        $issue_value = $this->get('issue');
+
+        if (ctype_digit($pages_value)) {
+            // Digit-only
+            if ((int) $pages_value < 10000) {
+                return false;
+            }
+
+            // Direct DOI suffix match
+            if (str_ends_with($doi_lower, $pages_value)) {
+                $match_found = true;
+            }
+
+            // 8-digit with dot insertion
+            if (!$match_found && mb_strlen($pages_value) === 8) {
+                $dot_pages = mb_substr($pages_value, 0, 4) . '.' . mb_substr($pages_value, 4, 4);
+                if (str_ends_with($doi_lower, $dot_pages)) {
+                    $match_found = true;
+                }
+            }
+        } else {
+            // Alpha-numeric
+
+            // Direct 5+ char DOI suffix match
+            if (mb_strlen($pages_value) > 4 && str_ends_with($doi_lower, $pages_lower)) {
+                $match_found = true;
+            }
+
+            // 'e' prefix: strip leading 'e', match remainder
+            if (!$match_found && preg_match('/^e([a-z\d]+)$/i', $pages_value, $m)) {
+                $epage = mb_strtolower($m[1]);
+                if (str_ends_with($doi_lower, $epage)) {
+                    $match_found = true;
+                }
+            }
+
+            // 'CD' prefix + digits: match with .pub\d suffix
+            if (!$match_found && preg_match('/^cd\d+$/i', $pages_value)) {
+                if (preg_match('/' . preg_quote($pages_lower, '/') . '\.pub\d$/i', $doi_lower)) {
+                    $match_found = true;
+                }
+            }
+        }
+
+        if ($match_found) {
+            // Delete issue if it has the same value
+            if ($issue_value !== '' && $issue_value === $pages_value) {
+                $this->forget('issue');
+            }
+
+            // Rename page or pages to article-number
+            $this->rename($page_param, 'article-number');
+            $this->mod_article_number = true;
+            report_action("Potential article number detected — renamed \"$page_param\" to \"article-number\"");
+            return true;
+        }
+
+        return false;
     }
 
     public function verify_doi(): bool {
@@ -7423,6 +7557,8 @@ final class Template
         $ret['ref'] = $this->mod_ref;
         $ret['na'] = $this->mod_na;
         $ret['issue_citebook'] = $this->mod_issue_citebook;
+        $ret['article_number'] = $this->mod_article_number;
+        $ret['article_number_iucn'] = $this->mod_article_number_iucn;
         return $ret;
     }
 

--- a/src/includes/constants/translations.php
+++ b/src/includes/constants/translations.php
@@ -112,6 +112,8 @@ const MK_TRANS = [
     'Linked from' => 'Поврзано од',
     '[[Category:' => '[[Категорија:',
     'Whitelisted category ' => 'Категорија на белата листа ',
+    'Converted page numbers to article numbers. ' => 'Конвертирани страници во броеви на статии. ',
+    'Converted deprecated page parameter to article-number in cite IUCN. ' => 'Конвертиран депрециран параметар за страници во article-number во cite IUCN. ',
 ];
 
 const RU_TRANS = [
@@ -140,6 +142,8 @@ const RU_TRANS = [
     'Linked from' => 'Ссылки с',
     '[[Category:' => '[[Категория:',
     'Whitelisted category ' => 'Категория из белого списка ',
+    'Converted page numbers to article numbers. ' => 'Номера страниц преобразованы в номера статей. ',
+    'Converted deprecated page parameter to article-number in cite IUCN. ' => 'Устаревший параметр page преобразован в article-number в cite IUCN. ',
 ];
 
 const SR_TRANS = [
@@ -168,6 +172,8 @@ const SR_TRANS = [
     'Linked from' => 'Повезано од',
     '[[Category:' => '[[Категорија:',
     'Whitelisted category ' => 'Категорија са беле листе ',
+    'Converted page numbers to article numbers. ' => 'Конвертоване странице у бројеве чланака. ',
+    'Converted deprecated page parameter to article-number in cite IUCN. ' => 'Застарели параметар page конвертован у article-number у cite IUCN. ',
 ];
 
 const VI_TRANS = [
@@ -196,4 +202,6 @@ const VI_TRANS = [
     'Linked from' => 'Liên kết từ',
     '[[Category:' => '[[Thể loại:',
     'Whitelisted category ' => 'Danh mục được cho phép ',
+    'Converted page numbers to article numbers. ' => 'Đã chuyển đổi số trang thành số bài viết. ',
+    'Converted deprecated page parameter to article-number in cite IUCN. ' => 'Tham số page không còn được dùng đã chuyển đổi thành article-number trong cite IUCN. ',
 ];

--- a/tests/phpunit/includes/TemplatePart2Test.php
+++ b/tests/phpunit/includes/TemplatePart2Test.php
@@ -2549,4 +2549,152 @@ final class TemplatePart2Test extends testBaseClass {
         $template = $this->make_citation($text);
         $this->assertSame('936346', $template->get2('ssrn'));
     }
+
+    public function testDetectArticleNumberDigitDirect(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|pages=100393|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('100393', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberEightDigit(): void {
+        $text = "{{cite journal|doi=10.1098/rsbl.2017.0301|pages=20170301|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('20170301', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberAlphaDirect(): void {
+        $text = "{{cite journal|doi=10.1002/14651858.CD004052|pages=CD004052|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('CD004052', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberEPrefix(): void {
+        $text = "{{cite journal|doi=10.1126/sciadv.adl0822|pages=eadl0822|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('eadl0822', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberCDPub(): void {
+        $text = "{{cite journal|doi=10.1002/14651858.CD005216.pub2|pages=CD005216|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('CD005216', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberEPrefixSkipNonAlpha(): void {
+        // Lua requires entire value to match e[alphanumeric]+ — dots should prevent match
+        $text = "{{cite journal|doi=10.1126/sciadv.adl0822|pages=e.adl0822|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('e.adl0822', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberSkipComma(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|pages=100,393|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('100,393', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberSkipDash(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|pages=100393-100400|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('100393-100400', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberSkipURL(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|pages=https://example.com|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+    }
+
+    public function testDetectArticleNumberSkipZootaxa(): void {
+        // Both doi and page contain "zootaxa" — should skip (false positive)
+        $text = "{{cite journal|doi=10.11646/zootaxa.53401.1.5|pages=zootaxa53401|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('zootaxa53401', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberSkipUnder10000(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.9999|pages=9999|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('9999', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberIUCN(): void {
+        $text = "{{cite IUCN|page=e.123|title=Test Species|year=2020}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('e.123', $template->get2('article-number'));
+        $this->assertNull($template->get2('page'));
+    }
+
+    public function testDetectArticleNumberDeleteIssue(): void {
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|pages=100393|issue=100393|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('100393', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+        $this->assertNull($template->get2('issue'));
+    }
+
+    public function testDetectArticleNumberSkipCiteBook(): void {
+        $text = "{{cite book|doi=10.1016/j.gfs.2020.100393|pages=100393|title=Test Book}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('100393', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberSkipCitationWithoutJournal(): void {
+        $text = "{{citation|doi=10.1016/j.gfs.2020.100393|pages=100393}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertNull($template->get2('article-number'));
+        $this->assertSame('100393', $template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberCitationWithJournal(): void {
+        $text = "{{citation|doi=10.1016/j.gfs.2020.100393|pages=100393|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('100393', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
+
+    public function testDetectArticleNumberPageParam(): void {
+        // Test using singular |page= (not |pages=) to exercise the has('page') branch
+        $text = "{{cite journal|doi=10.1016/j.gfs.2020.100393|page=100393|journal=Test Journal}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('100393', $template->get2('article-number'));
+        $this->assertNull($template->get2('page'));
+    }
+
+    public function testDetectArticleNumberCitationWithWork(): void {
+        // Citation template with |work= instead of |journal= should also be eligible
+        $text = "{{citation|doi=10.1016/j.gfs.2020.100393|pages=100393|work=Test Work}}";
+        $template = $this->make_citation($text);
+        $template->final_tidy();
+        $this->assertSame('100393', $template->get2('article-number'));
+        $this->assertNull($template->get2('pages'));
+    }
 }

--- a/tests/phpunit/includes/TemplatePart3Test.php
+++ b/tests/phpunit/includes/TemplatePart3Test.php
@@ -1474,7 +1474,9 @@ EP - 999 }}';
                             'names' => false,
                             'ref' => false,
                             'na' => false,
-                            'issue_citebook' => false];
+                            'issue_citebook' => false,
+                            'article_number' => false,
+                            'article_number_iucn' => false];
         $this->assertEqualsCanonicalizing($expected, $array);
         $this->assertNull($template->get2('citation_bot_placeholder_bare_url'));
     }
@@ -1483,7 +1485,7 @@ EP - 999 }}';
         $text = '{{new cambridge medieval history|ed10=That Guy}}';
         $template = $this->prepare_citation($text);
         $array = $template->modifications();
-        $expected = ['modifications' => [], 'additions' => [], 'deletions' => [], 'changeonly' => [], 'dashes' => false, 'names' => false, 'ref' => false, 'na' => false, 'issue_citebook' => false];
+        $expected = ['modifications' => [], 'additions' => [], 'deletions' => [], 'changeonly' => [], 'dashes' => false, 'names' => false, 'ref' => false, 'na' => false, 'issue_citebook' => false, 'article_number' => false, 'article_number_iucn' => false];
         $this->assertEqualsCanonicalizing($expected, $array);
     }
 


### PR DESCRIPTION
## Summary

Implements Monkbot task 21 core logic: detect when `|page=` or `|pages=` in citation templates contain an article number (matching DOI suffix) and rename to `|article-number=`. Also handles the `{{cite IUCN}}` special case. As per requested.

### Detection patterns (ported from Monkbot C#)
| Pattern | Example | Condition |
|---------|---------|-----------|
| Digit direct | `page=100393`, `doi=...100393` | digit-only >= 10000, DOI ends with value |
| 8-digit dot-insertion | `page=20170301` → `2017.0301`, `doi=...2017.0301` | insert `.` at midpoint, match DOI suffix |
| Alphanumeric direct | `page=CD004052`, `doi=...CD004052` | 5+ chars, DOI ends with value |
| 'e' prefix | `page=eadl0822` → `adl0822`, `doi=...adl0822` | starts with `e`, strip it, match DOI suffix |
| CD prefix + .pubN | `page=CD005216`, `doi=...CD005216.pub2` | DOI ends with `value.pub\d` |

### Skip conditions
- Range/list chars (`, ; _ − – — ‒ % -`), URLs, digit-only < 10000
- Zootaxa/DDI false positives (both DOI and page contain the string)

### Additional
- `{{cite IUCN}}`: renames `page=e.*` → `article-number=e.*` regardless of DOI
- Issue deleted if it duplicates the article-number value
- Modification flags with edit summary messages + translations for mk/ru/sr/vi wikis
- No API calls — safe for fast mode
- 16 new tests covering all patterns and skip conditions

